### PR TITLE
Add option to ignore network errors when attempting to log

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Creates a new GoodHttp object where:
 - `endpoint` - full path to remote server to transmit logs.
 - `config` - configuration object
   - `[threshold]` - number of events to hold before transmission. Defaults to `20`. Set to `0` to have every event start transmission instantly. It is strongly suggested to have a set threshold to make data transmission more efficient.
-  - `[errorThreshold]` - number of consecutive failed transmissions allowed. Failed events will be included in the next transmission until they are successfully logged or the threshold is reached (whichever comes first) at which point they will be cleared. Defaults to `0`.
-  - `[ignoreRequestErrors]` - if set to `true` network errors (`ECONNRESET`, `ECONNREFUSED`, etc.) will not hault future log attempts. Defaults to `false`.
+  - `[errorThreshold]` - number of consecutive failed transmissions allowed (`ECONNRESET`, `ECONNREFUSED`, etc). Defaults to `0`. Failed events will be included in the next transmission until they are successfully logged or the threshold is reached (whichever comes first) at which point they will be cleared. Set to `Infinity` (or `null` if configuration is JSON) to ignore all errors (*note: this is potentially dangerous as failed logs will continue to grow and could cause the process to run out of memory*).
   - `[wreck]` - configuration object to pass into [`wreck`](https://github.com/hapijs/wreck#advanced). Defaults to `{ timeout: 60000, headers: {} }`. `content-type` is always "application/json".
 
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Creates a new GoodHttp object where:
 - `endpoint` - full path to remote server to transmit logs.
 - `config` - configuration object
   - `[threshold]` - number of events to hold before transmission. Defaults to `20`. Set to `0` to have every event start transmission instantly. It is strongly suggested to have a set threshold to make data transmission more efficient.
+  - `[errorThreshold]` - number of consecutive failed transmissions allowed. Failed events will be included in the next transmission until they are successfully logged or the threshold is reached (whichever comes first) at which point they will be cleared. Defaults to `0`.
   - `[ignoreRequestErrors]` - if set to `true` network errors (`ECONNRESET`, `ECONNREFUSED`, etc.) will not hault future log attempts. Defaults to `false`.
   - `[wreck]` - configuration object to pass into [`wreck`](https://github.com/hapijs/wreck#advanced). Defaults to `{ timeout: 60000, headers: {} }`. `content-type` is always "application/json".
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Creates a new GoodHttp object where:
 - `endpoint` - full path to remote server to transmit logs.
 - `config` - configuration object
   - `[threshold]` - number of events to hold before transmission. Defaults to `20`. Set to `0` to have every event start transmission instantly. It is strongly suggested to have a set threshold to make data transmission more efficient.
-  - `[errorThreshold]` - number of consecutive failed transmissions allowed (`ECONNRESET`, `ECONNREFUSED`, etc). Defaults to `0`. Failed events will be included in the next transmission until they are successfully logged or the threshold is reached (whichever comes first) at which point they will be cleared. Set to `Infinity` (or `null` if configuration is JSON) to ignore all errors (*note: this is potentially dangerous as failed logs will continue to grow and could cause the process to run out of memory*).
+  - `[errorThreshold]` - number of consecutive failed transmissions allowed (`ECONNRESET`, `ECONNREFUSED`, etc). Defaults to `0`. Failed events will be included in the next transmission until they are successfully logged or the threshold is reached (whichever comes first) at which point they will be cleared. Set to `null` to ignore all errors and always clear events.
   - `[wreck]` - configuration object to pass into [`wreck`](https://github.com/hapijs/wreck#advanced). Defaults to `{ timeout: 60000, headers: {} }`. `content-type` is always "application/json".
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Creates a new GoodHttp object where:
 
 - `endpoint` - full path to remote server to transmit logs.
 - `config` - configuration object
-	- `[threshold]` - number of events to hold before transmission. Defaults to `20`. Set to `0` to have every event start transmission instantly. It is strongly suggested to have a set threshold to make data transmission more efficient.
+  - `[threshold]` - number of events to hold before transmission. Defaults to `20`. Set to `0` to have every event start transmission instantly. It is strongly suggested to have a set threshold to make data transmission more efficient.
+  - `[ignoreRequestErrors]` - if set to `true` network errors (`ECONNRESET`, `ECONNREFUSED`, etc.) will not hault future log attempts. Defaults to `false`.
   - `[wreck]` - configuration object to pass into [`wreck`](https://github.com/hapijs/wreck#advanced). Defaults to `{ timeout: 60000, headers: {} }`. `content-type` is always "application/json".
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,19 +14,30 @@ const internals = {
         threshold: 20,
         errorThreshold: 0,
         schema: 'good-http',
-        ignoreRequestErrors: false,
         wreck: {
             timeout: 60000,
             headers: {}
         }
     },
-    host: Os.hostname()
+    host: Os.hostname(),
+    shouldIgnoreError(errorThreshold, failureCount) {
+
+        return errorThreshold === Infinity || failureCount < errorThreshold;
+    }
 };
 
 class GoodHttp extends Stream.Writable {
     constructor(endpoint, config) {
 
         config = config || {};
+
+        // Infinity is not available in JSON, so assume explicit null means Infinity
+        if (config.errorThreshold === null) {
+            config = Object.assign({}, config, {
+                errorThreshold: Infinity
+            });
+        }
+
         const settings = Object.assign({}, internals.defaults, config);
 
         super({ objectMode: true, decodeStrings: false });
@@ -47,15 +58,13 @@ class GoodHttp extends Stream.Writable {
         if (this._data.length >= this._settings.threshold) {
             this._sendMessages((err) => {
 
-                if (err && this._failureCount < this._settings.errorThreshold - 1) {
+                if (err && internals.shouldIgnoreError(this._settings.errorThreshold, this._failureCount)) {
                     this._failureCount++;
                     return callback();
                 }
 
-                // always clear the data so we don't buffer this forever if there is ever a failed POST
                 this._data = [];
                 this._failureCount = 0;
-                err = this._settings.ignoreRequestErrors ? null : err;
 
                 return callback(err);
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ const internals = {
     defaults: {
         threshold: 20,
         schema: 'good-http',
+        ignoreRequestErrors: false,
         wreck: {
             timeout: 60000,
             headers: {}
@@ -68,7 +69,11 @@ class GoodHttp extends Stream.Writable {
 
         // Prevent this from user tampering
         wreckOptions.headers['content-type'] = 'application/json';
-        Wreck.request('post', this._endpoint, wreckOptions, callback);
+        Wreck.request('post', this._endpoint, wreckOptions, (err, payload) => {
+
+            err = this._settings.ignoreRequestErrors ? null : err;
+            return callback && callback(err, payload);
+        });
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ const Wreck = require('wreck');
 const internals = {
     defaults: {
         threshold: 20,
+        errorThreshold: 0,
         schema: 'good-http',
         ignoreRequestErrors: false,
         wreck: {
@@ -32,6 +33,7 @@ class GoodHttp extends Stream.Writable {
         this._settings = settings;
         this._endpoint = endpoint;
         this._data = [];
+        this._failureCount = 0;
 
         // Standard users
         this.once('finish', () => {
@@ -45,8 +47,16 @@ class GoodHttp extends Stream.Writable {
         if (this._data.length >= this._settings.threshold) {
             this._sendMessages((err) => {
 
+                if (err && this._failureCount < this._settings.errorThreshold - 1) {
+                    this._failureCount++;
+                    return callback();
+                }
+
                 // always clear the data so we don't buffer this forever if there is ever a failed POST
                 this._data = [];
+                this._failureCount = 0;
+                err = this._settings.ignoreRequestErrors ? null : err;
+
                 return callback(err);
             });
         }
@@ -69,11 +79,7 @@ class GoodHttp extends Stream.Writable {
 
         // Prevent this from user tampering
         wreckOptions.headers['content-type'] = 'application/json';
-        Wreck.request('post', this._endpoint, wreckOptions, (err, payload) => {
-
-            err = this._settings.ignoreRequestErrors ? null : err;
-            return callback && callback(err, payload);
-        });
+        Wreck.request('post', this._endpoint, wreckOptions, callback);
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,9 +20,9 @@ const internals = {
         }
     },
     host: Os.hostname(),
-    shouldIgnoreError(errorThreshold, failureCount) {
+    shouldHoldData(errorThreshold, failureCount) {
 
-        return errorThreshold === Infinity || failureCount < errorThreshold;
+        return errorThreshold !== null && failureCount < errorThreshold;
     }
 };
 
@@ -30,14 +30,6 @@ class GoodHttp extends Stream.Writable {
     constructor(endpoint, config) {
 
         config = config || {};
-
-        // Infinity is not available in JSON, so assume explicit null means Infinity
-        if (config.errorThreshold === null) {
-            config = Object.assign({}, config, {
-                errorThreshold: Infinity
-            });
-        }
-
         const settings = Object.assign({}, internals.defaults, config);
 
         super({ objectMode: true, decodeStrings: false });
@@ -58,7 +50,7 @@ class GoodHttp extends Stream.Writable {
         if (this._data.length >= this._settings.threshold) {
             this._sendMessages((err) => {
 
-                if (err && internals.shouldIgnoreError(this._settings.errorThreshold, this._failureCount)) {
+                if (err && internals.shouldHoldData(this._settings.errorThreshold, this._failureCount)) {
                     this._failureCount++;
                     return callback();
                 }
@@ -66,7 +58,7 @@ class GoodHttp extends Stream.Writable {
                 this._data = [];
                 this._failureCount = 0;
 
-                return callback(err);
+                return callback(this._settings.errorThreshold !== null && err);
             });
         }
         else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,11 +19,7 @@ const internals = {
             headers: {}
         }
     },
-    host: Os.hostname(),
-    shouldHoldData(errorThreshold, failureCount) {
-
-        return errorThreshold !== null && failureCount < errorThreshold;
-    }
+    host: Os.hostname()
 };
 
 class GoodHttp extends Stream.Writable {
@@ -31,6 +27,10 @@ class GoodHttp extends Stream.Writable {
 
         config = config || {};
         const settings = Object.assign({}, internals.defaults, config);
+
+        if (settings.errorThreshold === null) {
+            settings.errorThreshold = -Infinity;
+        }
 
         super({ objectMode: true, decodeStrings: false });
         this._settings = settings;
@@ -50,7 +50,7 @@ class GoodHttp extends Stream.Writable {
         if (this._data.length >= this._settings.threshold) {
             this._sendMessages((err) => {
 
-                if (err && internals.shouldHoldData(this._settings.errorThreshold, this._failureCount)) {
+                if (err && this._failureCount < this._settings.errorThreshold) {
                     this._failureCount++;
                     return callback();
                 }
@@ -58,7 +58,7 @@ class GoodHttp extends Stream.Writable {
                 this._data = [];
                 this._failureCount = 0;
 
-                return callback(this._settings.errorThreshold !== null && err);
+                return callback(this._settings.errorThreshold !== -Infinity && err);
             });
         }
         else {

--- a/test/index.js
+++ b/test/index.js
@@ -203,11 +203,9 @@ describe('GoodHttp', () => {
 
     it('makes a last attempt to send any remaining log entries on "finish"',  { plan: 2 }, (done) => {
 
-        let hitCount = 0;
         const server = Http.createServer((req, res) => {
 
             let data = '';
-            hitCount++;
 
             req.on('data', (chunk) => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -243,9 +243,10 @@ describe('GoodHttp', () => {
         });
     });
 
-    it('doesn\'t clear data on error until errorThreshold is reached', { plan: 8 }, (done) => {
+    it('doesn\'t clear data on error until errorThreshold is reached', { plan: 15 }, (done) => {
 
         let hitCount = 0;
+        let errorCallCount = 0;
         const server = Http.createServer((req, res) => {
 
             let data = '';
@@ -260,8 +261,13 @@ describe('GoodHttp', () => {
                 const payload = JSON.parse(data);
                 const events = payload.events;
 
+                expect(errorCallCount).to.equal(0);
                 expect(events).to.have.length(hitCount);
-                expect(events[hitCount - 1].id).to.equal(hitCount - 1);
+
+                for (let i = 0; i < hitCount; ++i) {
+                    expect(events[i].id).to.equal(i);
+                }
+
                 req.socket.destroy();
             });
         });
@@ -276,8 +282,10 @@ describe('GoodHttp', () => {
 
             reporter.on('error', () => {
 
+                errorCallCount++;
                 expect(hitCount).to.equal(3);
                 expect(reporter._data).to.have.length(0);
+                expect(errorCallCount).to.equal(1);
                 server.close(done);
             });
 


### PR DESCRIPTION
Adds ability to ignore network errors when attempting to send logs so logging can continue, even if a single log failed to send. For instance, we were seeing all our logs drop off because a single request to our logging service received an `ECONNRESET`.