### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-http",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "repository": "git://github.com/hapijs/good-http",
   "description": "Http(s) broadcasting for Good process monitor",
   "main": "lib/index.js",
@@ -9,7 +9,7 @@
     "test-cov-html": "lab -m 5000 -r html -o coverage.html -La code"
   },
   "dependencies": {
-    "fast-safe-stringify": "1.0.9",
+    "fast-safe-stringify": "1.1.0",
     "wreck": "7.x.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-http",
-  "version": "6.1.1",
+  "version": "6.1.0",
   "repository": "git://github.com/hapijs/good-http",
   "description": "Http(s) broadcasting for Good process monitor",
   "main": "lib/index.js",


### PR DESCRIPTION
Every version of fast-safe-stringify prior to v1.1.0 has been deprecated, see: https://github.com/davidmarkclements/fast-safe-stringify/issues/4